### PR TITLE
Fix syntax error in Servers::SyncJob while calling Server.log!

### DIFF
--- a/app/jobs/servers/sync_job.rb
+++ b/app/jobs/servers/sync_job.rb
@@ -4,7 +4,7 @@ class Servers::SyncJob < ApplicationJob
   rescue_from Exceptions::CommandError do |e|
     Rails.logger.error("[Servers::SyncJob][CommandError] Exception: #{e.message}")
     notify_socket!(:server_sync_errored, true, 'error')
-    @server.log! "SYNC", e.message, 'error'
+    @server.log! "SYNC", e.message, status: 'error'
     @server.error!
   end
 


### PR DESCRIPTION
Server.log! takes a hash as the third parameter while it was given a string.

Fixes Issue #13 